### PR TITLE
Compatibility update for v2026.01

### DIFF
--- a/assets/javascripts/discourse/components/rating-object.hbs
+++ b/assets/javascripts/discourse/components/rating-object.hbs
@@ -51,12 +51,12 @@
       action=this.updateObject
       actionParam=this.object
       label="admin.ratings.type.update"
-      icon="save"
+      icon="check"
       disabled=this.saveDisabled
     }}
   {{/if}}
 
-  {{d-button action=this.destroyObject actionParam=this.object icon="times"}}
+  {{d-button action=this.destroyObject actionParam=this.object icon="xmark"}}
 </td>
 
 {{#if this.error}}

--- a/assets/javascripts/discourse/components/rating-type.hbs
+++ b/assets/javascripts/discourse/components/rating-type.hbs
@@ -37,11 +37,11 @@
         action=this.updateType
         actionParam=this.type
         label="admin.ratings.type.update"
-        icon="save"
+        icon="check"
         disabled=this.updateDisabled
       }}
     {{/if}}
 
-    {{d-button action=this.destroyType actionParam=this.type icon="times"}}
+    {{d-button action=this.destroyType actionParam=this.type icon="xmark"}}
   {{/if}}
 </td>

--- a/assets/javascripts/discourse/connectors/post-meta-data-poster-name-user-link/post-ratings.gjs
+++ b/assets/javascripts/discourse/connectors/post-meta-data-poster-name-user-link/post-ratings.gjs
@@ -3,7 +3,6 @@ import { htmlSafe } from "@ember/template";
 import { ratingListHtml } from "../../lib/rating-utilities";
 
 export default class PostRatings extends Component {
-
   get showRatings() {
     return this.args.post.ratings && this.args.post.ratings.length > 0;
   }

--- a/assets/javascripts/discourse/connectors/post-meta-data-poster-name-user-link/post-ratings.gjs
+++ b/assets/javascripts/discourse/connectors/post-meta-data-poster-name-user-link/post-ratings.gjs
@@ -1,0 +1,21 @@
+import Component from "@glimmer/component";
+import { htmlSafe } from "@ember/template";
+import { ratingListHtml } from "../../lib/rating-utilities";
+
+export default class PostRatings extends Component {
+
+  get showRatings() {
+    return this.args.post.ratings && this.args.post.ratings.length > 0;
+  }
+
+  get ratingList() {
+    return htmlSafe(ratingListHtml(this.args.post.ratings));
+  }
+
+  <template>
+    {{yield}}
+    {{#if this.showRatings}}
+      <span class="post-ratings">{{this.ratingList}}</span>
+    {{/if}}
+  </template>
+}

--- a/assets/javascripts/discourse/controllers/admin-plugins/ratings.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins/ratings.js
@@ -3,7 +3,7 @@ import { action } from "@ember/object";
 import { notEmpty } from "@ember/object/computed";
 import { service } from "@ember/service";
 import { i18n } from "discourse-i18n";
-import RatingType from "../models/rating-type";
+import RatingType from "../../models/rating-type";
 
 export default class AdminPluginsRatingsController extends Controller {
   @service dialog;

--- a/assets/javascripts/discourse/initializers/initialize-ratings.js
+++ b/assets/javascripts/discourse/initializers/initialize-ratings.js
@@ -13,7 +13,6 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
-import { ratingListHtml } from "../lib/rating-utilities";
 
 const PLUGIN_ID = "discourse-ratings";
 

--- a/assets/javascripts/discourse/initializers/initialize-ratings.js
+++ b/assets/javascripts/discourse/initializers/initialize-ratings.js
@@ -33,7 +33,7 @@ export default {
     withPluginApi("0.10.0", (api) => {
       const currentUser = api.getCurrentUser();
 
-      api.includePostAttributes("ratings");
+      api.addTrackedPostProperties("ratings");
 
       api.decorateWidget("poster-name:after", function (helper) {
         const post = helper.getModel();

--- a/assets/javascripts/discourse/initializers/initialize-ratings.js
+++ b/assets/javascripts/discourse/initializers/initialize-ratings.js
@@ -35,25 +35,6 @@ export default {
 
       api.addTrackedPostProperties("ratings");
 
-      api.decorateWidget("poster-name:after", function (helper) {
-        const post = helper.getModel();
-
-        if (post && post.topic && post.topic.show_ratings && post.ratings) {
-          return helper.rawHtml(ratingListHtml(post.ratings));
-        }
-      });
-
-      api.reopenWidget("poster-name", {
-        buildClasses() {
-          const post = this.findAncestorModel();
-          let classes = [];
-          if (post && post.topic && post.topic.show_ratings && post.ratings) {
-            classes.push("has-ratings");
-          }
-          return classes;
-        },
-      });
-
       api.modifyClass("model:composer", {
         pluginId: PLUGIN_ID,
         editingPostWithRatings: and("editingPost", "post.ratings.length"),

--- a/assets/javascripts/discourse/routes/admin-plugins/ratings.js
+++ b/assets/javascripts/discourse/routes/admin-plugins/ratings.js
@@ -4,8 +4,8 @@ import { service } from "@ember/service";
 import { all } from "rsvp";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
-import RatingObject from "../models/rating-object";
-import RatingType from "../models/rating-type";
+import RatingObject from "../../models/rating-object";
+import RatingType from "../../models/rating-type";
 
 const noneType = "none";
 

--- a/assets/stylesheets/common/ratings.scss
+++ b/assets/stylesheets/common/ratings.scss
@@ -19,8 +19,12 @@
   }
 }
 
-.topic-meta-data .names.has-ratings {
-  align-items: flex-start;
+.topic-meta-data .names .rating-list {
+  margin-left: 1em;
+  .rating-type {
+    // there is a .names span.first { font-weight: bold; }  in core... :sobs:
+    font-weight: normal;
+  }
 
   .rating {
     margin: 0 5px 0 0;

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 # name: discourse-ratings
 # about: A Discourse plugin that lets you use topics to rate things
-# version: 0.2.3
-# authors: Angus McLeod, Faizaan Gagan
+# version: 1.0
+# authors: Pavilion
 # url: https://github.com/paviliondev/discourse-ratings
 # contact_emails: development@pavilion.tech
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -182,12 +182,7 @@ after_initialize do
     )
   end
 
-  add_to_serializer(:post, :ratings, respect_plugin_enabled: false) do
-    DiscourseRatings::Rating.serialize(object.ratings)
-  end
-
-  add_to_serializer(:post, :include_ratings?) do
-    # we need to explictly check for plugin enabled when defining custom include method
+  add_to_serializer(:post, :ratings, respect_plugin_enabled: false, include_condition: -> {
     SiteSetting.rating_enabled &&
       (
         !SiteSetting.rating_hide_except_own_entry ||
@@ -196,6 +191,8 @@ after_initialize do
               (scope.current_user.staff? || scope.current_user.id === object.user.id)
           )
       )
+  }) do
+    DiscourseRatings::Rating.serialize(object.ratings)
   end
 
   ###### Topic ######
@@ -230,10 +227,10 @@ after_initialize do
       object.topic.ratings.present?
   end
 
-  add_to_serializer(:topic_view, :user_can_rate) { object.topic.user_can_rate(scope.current_user) }
-
-  add_to_serializer(:topic_view, :include_user_can_rate?) do
+  add_to_serializer(:topic_view, :user_can_rate, include_condition: -> {
     scope.current_user && object.topic.rating_enabled?
+  }) do
+    object.topic.user_can_rate(scope.current_user)
   end
 
   ::Topic.singleton_class.prepend TopicRatingsExtension


### PR DESCRIPTION
Fixed various things for v2026.01:

- replace widget with connector component
- FA6 icons
- modernize `_include` condition on serializer
- paths for Ember controller and route
- use `api.addTrackedPostProperties` instead of `api.includePostAttributes`